### PR TITLE
A leak of self.noticeView

### DIFF
--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -261,6 +261,7 @@
                 } completion:^ (BOOL finished) {
                     if (finished) {                        
                         // Cleanup
+                        [self.noticeView removeFromSuperview];
                         self.noticeView = nil;
                         self.imageView = nil;
                         self.titleLabel = nil;


### PR DESCRIPTION
There is a leak of self.noticeView. It's still here after cleanup in a completion block.
The call [self.noticeView removeFromSuperview] fixes this leak.
