### PR TITLE
Added KVO for UIScrollView contentOffset

### DIFF
--- a/NoticeView/WBNoticeView/WBNoticeView.h
+++ b/NoticeView/WBNoticeView/WBNoticeView.h
@@ -91,6 +91,11 @@
  */
 @property (nonatomic, readwrite, getter = isSticky) BOOL sticky;
 
+/**
+A Boolean value that determines whether the notice is hidden.
+ */
+@property(nonatomic, readonly, getter = isHidden) BOOL hidden;
+
 ///----------------------------------------
 /// @name Showing and Dismissing the Notice
 ///----------------------------------------

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -70,6 +70,24 @@
     [self doesNotRecognizeSelector:_cmd];
 }
 
+#pragma mark - KVO
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+    @try {
+        if (object && [object isKindOfClass:[UIScrollView class]] && [keyPath isEqualToString:@"contentOffset"]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                CGRect newFrame = self.gradientView.frame;
+                newFrame.origin.y = ((UIScrollView *)object).contentOffset.y;
+                self.gradientView.frame = newFrame;
+                [self.view bringSubviewToFront:self.gradientView];
+            });
+        }
+    }
+    @catch (NSException *exception) {
+        
+    }
+}
+
 #pragma mark -
 
 - (void)displayNotice

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -70,6 +70,11 @@
     [self doesNotRecognizeSelector:_cmd];
 }
 
+- (BOOL)isHidden
+{
+	return self.gradientView == nil;
+}
+
 #pragma mark - KVO
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
@@ -144,7 +149,7 @@
 {
     [UIView animateWithDuration:duration delay:delay options:UIViewAnimationOptionCurveEaseOut animations:^ {
         if ([self.view isKindOfClass:[UIScrollView class]]) {
-                [self.view removeObserver:self forKeyPath:@"contentOffset"];                   
+			[self.view removeObserver:self forKeyPath:@"contentOffset"];
         }
         CGRect newFrame = self.gradientView.frame;
         newFrame.origin.y = hiddenYOrigin;


### PR DESCRIPTION
If you add a noticeView to a scrollView you can use KVO to detect user's scroll and move the view.

<del>Example:</del>

<pre><code><del>notice = [WBSuccessNoticeView successNoticeInView:self.view title:@"Test"];
[notice setOriginY:self.tableView.contentOffset.y];
__weak WBNoticeView *noticePointer = notice;
[self.tableView addObserver:notice forKeyPath:@"contentOffset" options:NSKeyValueObservingOptionNew context:NULL];
[notice setDismissalBlock:^(BOOL dismissedInteractively) {
[self.tableView removeObserver:noticePointer forKeyPath:@"contentOffset"];
notice.view = nil;
}];
[notice show];</del></code></pre>
