### PR TITLE
WBNoticeViewSlidingMode introduced + bug fixes

### DIFF
--- a/NoticeView/WBNoticeView/WBBlueGradientView.m
+++ b/NoticeView/WBNoticeView/WBBlueGradientView.m
@@ -30,6 +30,7 @@
                           nil];
     
     [self.layer insertSublayer:gradient atIndex:0];
+    self.layer.needsDisplayOnBoundsChange = YES;
     
     UIView *firstTopBlueLine = [[UIView alloc]initWithFrame:CGRectMake(0.0, 0.0, self.bounds.size.width, 1.0)];
     firstTopBlueLine.backgroundColor = [UIColor colorWithRed:105/255.0f green:163/255.0f blue:208/255.0f alpha:1.0];

--- a/NoticeView/WBNoticeView/WBErrorNoticeView.m
+++ b/NoticeView/WBNoticeView/WBErrorNoticeView.m
@@ -59,21 +59,16 @@
     r.origin.y = self.titleLabel.frame.origin.y + self.titleLabel.frame.size.height;
     
     float noticeViewHeight = 0.0;
-    double currOsVersion = [[[UIDevice currentDevice]systemVersion]doubleValue];
-    if (currOsVersion >= 6.0f) {
-        noticeViewHeight = messageLabelHeight;
-    } else {
-        // Now we can determine the height of one line of text
-        r.size.height = self.messageLabel.frame.size.height * numberOfLines;
-        r.size.width = viewWidth - 70.0;
-        self.messageLabel.frame = r;
-        
-        // Calculate the notice view height
-        noticeViewHeight = 10.0;
-        if (numberOfLines > 1) {
-            noticeViewHeight += ((numberOfLines - 1) * messageLabelHeight);
-        }
-    }
+    // Now we can determine the height of one line of text
+    r.size.height = self.messageLabel.frame.size.height * numberOfLines;
+    r.size.width = viewWidth - 70.0;
+    self.messageLabel.frame = r;
+    
+    // Calculate the notice view height
+    noticeViewHeight = 10.0;
+    if (numberOfLines > 1) {
+        noticeViewHeight += ((numberOfLines - 1) * messageLabelHeight);
+    }   
     
     // Add some bottom margin for the notice view
     noticeViewHeight += 30.0;

--- a/NoticeView/WBNoticeView/WBErrorNoticeView.m
+++ b/NoticeView/WBNoticeView/WBErrorNoticeView.m
@@ -25,7 +25,7 @@
 - (void)show
 {
     // Obtain the screen width
-    CGFloat viewWidth = self.view.frame.size.width;
+    CGFloat viewWidth = self.view.bounds.size.width;
     
     // Locate the images
     NSString *path = [[[NSBundle mainBundle]resourcePath]stringByAppendingPathComponent:@"NoticeView.bundle"];

--- a/NoticeView/WBNoticeView/WBErrorNoticeView.m
+++ b/NoticeView/WBNoticeView/WBErrorNoticeView.m
@@ -79,7 +79,7 @@
     noticeViewHeight += 30.0;
     
     // Make sure we hide completely the view, including its shadow
-    float hiddenYOrigin = -noticeViewHeight - 20.0;
+    float hiddenYOrigin = self.slidingMode == WBNoticeViewSlidingModeDown ? -noticeViewHeight - 20.0: self.view.bounds.size.height;
     
     // Make and add the notice view
     self.gradientView = [[WBRedGradientView alloc] initWithFrame:CGRectMake(0.0, hiddenYOrigin, viewWidth, noticeViewHeight + 10.0)];

--- a/NoticeView/WBNoticeView/WBGrayGradientView.m
+++ b/NoticeView/WBNoticeView/WBGrayGradientView.m
@@ -29,6 +29,7 @@
                           nil];
     
     [self.layer insertSublayer:gradient atIndex:0];
+    self.layer.needsDisplayOnBoundsChange = YES;
     
     UIView *firstBotWhiteLine = [[UIView alloc]initWithFrame:CGRectMake(0.0, self.bounds.size.height - 1, self.frame.size.width, 1.0)];
     firstBotWhiteLine.backgroundColor = [UIColor colorWithRed:236/255.0f green:238/255.0f blue:239/255.0f alpha:1.0];

--- a/NoticeView/WBNoticeView/WBNoticeView.h
+++ b/NoticeView/WBNoticeView/WBNoticeView.h
@@ -8,6 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
+typedef enum WBNoticeViewSlidingMode {
+    WBNoticeViewSlidingModeUp,
+    WBNoticeViewSlidingModeDown,
+} WBNoticeViewSlidingMode;
+
 /**
  `WBNoticeView` objects provides a lightweight, non-intrusive means for displaying information to the user. The `WBNoticeView` class is an abstract class that encapsulates the interface common to all notice objects.
  */
@@ -90,6 +95,14 @@
  **Default**: `NO`
  */
 @property (nonatomic, readwrite, getter = isSticky) BOOL sticky;
+
+/**
+ Decides if the notice is shown sliding up from the bottom or down from the top
+ 
+ **Default**: 'WBNoticeViewSlidingModeDown'
+*/
+@property WBNoticeViewSlidingMode slidingMode;
+
 
 ///----------------------------------------
 /// @name Showing and Dismissing the Notice

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -55,6 +55,7 @@
         self.alpha = 1.0;
         self.delay = 2.0;
         self.tapToDismissEnabled = YES;
+        self.slidingMode = WBNoticeViewSlidingModeDown;
     }
     return self;
 }
@@ -90,6 +91,11 @@
         button.frame = self.gradientView.bounds;
         [button addTarget:self action:@selector(dismissNoticeInteractively) forControlEvents:UIControlEventTouchUpInside];
         [self.gradientView addSubview:button];
+    }
+    
+    //set default originY if WBNoticeViewSlidingModeUp
+    if ((self.slidingMode == WBNoticeViewSlidingModeUp) && (self.originY == 0)) {
+        self.originY = self.view.bounds.size.height - self.gradientView.bounds.size.height;
     }
     
     // Go ahead, display it

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -96,6 +96,10 @@
     //set default originY if WBNoticeViewSlidingModeUp
     if ((self.slidingMode == WBNoticeViewSlidingModeUp) && (self.originY == 0)) {
         self.originY = self.view.bounds.size.height - self.gradientView.bounds.size.height;
+        self.gradientView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
+    } else
+    {
+        self.gradientView.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleWidth;
     }
     
     // Go ahead, display it
@@ -105,15 +109,13 @@
         self.gradientView.frame = newFrame;
         self.gradientView.alpha = self.alpha;
     } completion:^ (BOOL finished) {
-        if (finished) {
-            // if it's not sticky, hide it automatically
-            if (self.tapToDismissEnabled && !self.isSticky) {
-                // Schedule a timer
-                self.displayTimer = [NSTimer scheduledTimerWithTimeInterval:self.delay target:self selector:@selector(dismissAfterTimerExpiration) userInfo:nil repeats:NO];
-            } else if (!self.isSticky) {
-                // Display for a while, then hide it again
-                [self dismissNoticeWithDuration:self.duration delay:self.delay hiddenYOrigin:self.hiddenYOrigin];
-            }
+        // if it's not sticky, hide it automatically
+        if (self.tapToDismissEnabled && !self.isSticky) {
+            // Schedule a timer
+            self.displayTimer = [NSTimer scheduledTimerWithTimeInterval:self.delay target:self selector:@selector(dismissAfterTimerExpiration) userInfo:nil repeats:NO];
+        } else if (!self.isSticky) {
+            // Display for a while, then hide it again
+            [self dismissNoticeWithDuration:self.duration delay:self.delay hiddenYOrigin:self.hiddenYOrigin];
         }
     }];
 }
@@ -122,14 +124,17 @@
 {
     [UIView animateWithDuration:duration delay:delay options:UIViewAnimationOptionCurveEaseOut animations:^ {
         CGRect newFrame = self.gradientView.frame;
-        newFrame.origin.y = hiddenYOrigin;
+        if (self.slidingMode == WBNoticeViewSlidingModeUp)  {
+            newFrame.origin.y = self.gradientView.frame.origin.y + self.gradientView.bounds.size.height;
+        } else
+        {
+            newFrame.origin.y = hiddenYOrigin;
+        }
         self.gradientView.frame = newFrame;
     } completion:^ (BOOL finished) {
-        if (finished) {  
-            if (self.dismissalBlock) self.dismissalBlock(NO);
-            // Cleanup
-            [self cleanup];
-        }
+        if (self.dismissalBlock) self.dismissalBlock(NO);
+        // Cleanup
+        [self cleanup];
     }];
 }
 

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -148,7 +148,7 @@
         // Clear the reference to the dismissal block so that the animation does invoke the block a second time
         self.dismissalBlock = nil;
     }
-    [self dismissNoticeWithDuration:self.duration delay:self.delay hiddenYOrigin:self.hiddenYOrigin];
+    [self dismissNoticeWithDuration:self.duration delay:0 hiddenYOrigin:self.hiddenYOrigin];
 }
 
 - (void)dismissAfterTimerExpiration

--- a/NoticeView/WBNoticeView/WBRedGradientView.m
+++ b/NoticeView/WBNoticeView/WBRedGradientView.m
@@ -30,6 +30,7 @@
                           nil];
     
     [self.layer insertSublayer:gradient atIndex:0];
+    self.layer.needsDisplayOnBoundsChange = YES;
     
     UIView *firstTopPinkLine = [[UIView alloc]initWithFrame:CGRectMake(0.0, 0.0, self.bounds.size.width, 1.0)];
     firstTopPinkLine.backgroundColor = [UIColor colorWithRed:211/255.0f green:82/255.0f blue:80/255.0f alpha:1.0];

--- a/NoticeView/WBNoticeView/WBStickyNoticeView.m
+++ b/NoticeView/WBNoticeView/WBStickyNoticeView.m
@@ -50,13 +50,12 @@
     
     // Calculate the notice view height
     float noticeViewHeight = 40.0;
-    float hiddenYOrigin = 0.0;
     if (numberOfLines > 1) {
         noticeViewHeight += (numberOfLines - 1) * messageLineHeight;
     }
     
     // Make sure we hide completely the view, including its shadow
-    hiddenYOrigin = -noticeViewHeight - 20.0;
+    float hiddenYOrigin = self.slidingMode == WBNoticeViewSlidingModeDown ? -noticeViewHeight - 20.0: self.view.bounds.size.height;
     
     // Make and add the notice view
     self.gradientView = [[WBGrayGradientView alloc] initWithFrame:CGRectMake(0.0, hiddenYOrigin, viewWidth, 32)];

--- a/NoticeView/WBNoticeView/WBStickyNoticeView.m
+++ b/NoticeView/WBNoticeView/WBStickyNoticeView.m
@@ -24,7 +24,7 @@
 - (void)show
 {
     // Obtain the screen width
-    CGFloat viewWidth = self.view.frame.size.width;
+    CGFloat viewWidth = self.view.bounds.size.width;
     
     // Locate the images
     NSString *path = [[[NSBundle mainBundle]resourcePath]stringByAppendingPathComponent:@"NoticeView.bundle"];

--- a/NoticeView/WBNoticeView/WBSuccessNoticeView.m
+++ b/NoticeView/WBNoticeView/WBSuccessNoticeView.m
@@ -45,13 +45,12 @@
     
     // Calculate the notice view height
     float noticeViewHeight = 40.0;
-    float hiddenYOrigin = 0.0;
     if (numberOfLines > 1) {
         noticeViewHeight += (numberOfLines - 1) * messageLineHeight;
     }
     
     // Make sure we hide completely the view, including its shadow
-    hiddenYOrigin = -noticeViewHeight - 20.0;
+    float hiddenYOrigin = self.slidingMode == WBNoticeViewSlidingModeDown ? -noticeViewHeight - 20.0: self.view.bounds.size.height;
     
     // Make and add the notice view
     self.gradientView = [[WBBlueGradientView alloc] initWithFrame:CGRectMake(0.0, hiddenYOrigin, viewWidth, noticeViewHeight + 10.0)];

--- a/NoticeView/WBNoticeView/WBSuccessNoticeView.m
+++ b/NoticeView/WBNoticeView/WBSuccessNoticeView.m
@@ -24,7 +24,7 @@
 - (void)show
 {
     // Obtain the screen width
-    CGFloat viewWidth = self.view.frame.size.width;
+    CGFloat viewWidth = self.view.bounds.size.width;
     
     // Locate the images
     NSString *path = [[[NSBundle mainBundle]resourcePath]stringByAppendingPathComponent:@"NoticeView.bundle"];


### PR DESCRIPTION
Hello and thank you for making NoticeView

I've added the ability to slide the notice from the bottom up without braking the existing API. I think NoticeView is the best looking on the market so I extended it because I needed a notice view that could stick to the bottom for http://kanbana.com/ipad

I've added the feature as a property like this:

```
WBSuccessNoticeView *notice = [WBSuccessNoticeView successNoticeInView:rootView title:title];
notice.slidingMode = WBNoticeViewSlidingModeUp;
[notice show];
```

I've also fixed this issue https://github.com/tciuro/NoticeView/issues/28 

and an error when you tried to dissmis a nonSticky notice manually

I hope you'll merge this into your main repository and update the pod. I use Cocoa pods so I hope to use NoticeView as a pod in the future

Best Regards
Troels Richter
http://twitter.com/troelsrichter
