### PR TITLE
Issue When Applying Notice View To View That Has Been Transformed.

### DIFF
--- a/NoticeView/WBNoticeView/WBErrorNoticeView.m
+++ b/NoticeView/WBNoticeView/WBErrorNoticeView.m
@@ -25,7 +25,7 @@
 - (void)show
 {
     // Obtain the screen width
-    CGFloat viewWidth = self.view.frame.size.width;
+    CGFloat viewWidth = self.view.bounds.size.width;
     
     // Locate the images
     NSString *path = [[[NSBundle mainBundle]resourcePath]stringByAppendingPathComponent:@"NoticeView.bundle"];

--- a/NoticeView/WBNoticeView/WBStickyNoticeView.m
+++ b/NoticeView/WBNoticeView/WBStickyNoticeView.m
@@ -24,7 +24,7 @@
 - (void)show
 {
     // Obtain the screen width
-    CGFloat viewWidth = self.view.frame.size.width;
+    CGFloat viewWidth = self.view.bounds.size.width;
     
     // Locate the images
     NSString *path = [[[NSBundle mainBundle]resourcePath]stringByAppendingPathComponent:@"NoticeView.bundle"];

--- a/NoticeView/WBNoticeView/WBSuccessNoticeView.m
+++ b/NoticeView/WBNoticeView/WBSuccessNoticeView.m
@@ -24,7 +24,7 @@
 - (void)show
 {
     // Obtain the screen width
-    CGFloat viewWidth = self.view.frame.size.width;
+    CGFloat viewWidth = self.view.bounds.size.width;
     
     // Locate the images
     NSString *path = [[[NSBundle mainBundle]resourcePath]stringByAppendingPathComponent:@"NoticeView.bundle"];


### PR DESCRIPTION
They Tito, 

I believe I found a bug when I was working on a project earlier today. NoticeView sets the width using the frame of the view its being applied to. If the view NoticeView is being applied to has been transformed (CGAffineTransform) the frame will not be valid. This caused weird behavior in the project I was using NoticeView in by making notice view's width only half the screen.

Source: https://developer.apple.com/library/ios/#documentation/UIKit/Reference/UIView_Class/UIView/UIView.html - See the warning on transform. 

Where I believe this is more of an issue is when using a modal that has been animated. I am trying to find a reputable source to quote but I am not 100% positive its true. But it looks like some of the modal transforms apply a transform to the UIView causing NoticeView to appear incorrectly.

The change is very minor so take a look and let me know what you think.

Thanks,
Rob
