### PR TITLE
Use NSOperationQueue to filter out duplicates.

### DIFF
--- a/NoticeView.xcodeproj/project.pbxproj
+++ b/NoticeView.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		748A6A5D157D0D06003C7655 /* WBStickyNoticeView.m in Sources */ = {isa = PBXBuildFile; fileRef = 748A6A5C157D0D06003C7655 /* WBStickyNoticeView.m */; };
 		7492FA45157C8CD700FB834C /* WBBlueGradientView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7492FA42157C8CD700FB834C /* WBBlueGradientView.m */; };
 		7492FA46157C8CD700FB834C /* WBRedGradientView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7492FA44157C8CD700FB834C /* WBRedGradientView.m */; };
+		FE07240C16BAB0F000B46F59 /* NSOperationQueue+WBNoticeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = FE07240B16BAB0F000B46F59 /* NSOperationQueue+WBNoticeExtensions.m */; };
+		FED81FA916B97A1C00254985 /* WBNoticeOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = FED81FA816B97A1C00254985 /* WBNoticeOperation.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -68,6 +70,10 @@
 		7492FA42157C8CD700FB834C /* WBBlueGradientView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WBBlueGradientView.m; sourceTree = "<group>"; };
 		7492FA43157C8CD700FB834C /* WBRedGradientView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WBRedGradientView.h; sourceTree = "<group>"; };
 		7492FA44157C8CD700FB834C /* WBRedGradientView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WBRedGradientView.m; sourceTree = "<group>"; };
+		FE07240A16BAB0F000B46F59 /* NSOperationQueue+WBNoticeExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSOperationQueue+WBNoticeExtensions.h"; sourceTree = "<group>"; };
+		FE07240B16BAB0F000B46F59 /* NSOperationQueue+WBNoticeExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSOperationQueue+WBNoticeExtensions.m"; sourceTree = "<group>"; };
+		FED81FA716B97A1C00254985 /* WBNoticeOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WBNoticeOperation.h; sourceTree = "<group>"; };
+		FED81FA816B97A1C00254985 /* WBNoticeOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WBNoticeOperation.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,8 +105,12 @@
 		592BDDE315645BEE00B78820 /* WBNoticeView */ = {
 			isa = PBXGroup;
 			children = (
+				FE07240A16BAB0F000B46F59 /* NSOperationQueue+WBNoticeExtensions.h */,
+				FE07240B16BAB0F000B46F59 /* NSOperationQueue+WBNoticeExtensions.m */,
 				746CBCFE1570A1D100B844B1 /* WBErrorNoticeView.h */,
 				746CBCFF1570A1D100B844B1 /* WBErrorNoticeView.m */,
+				FED81FA716B97A1C00254985 /* WBNoticeOperation.h */,
+				FED81FA816B97A1C00254985 /* WBNoticeOperation.m */,
 				746CBD061570A8FA00B844B1 /* WBSuccessNoticeView.h */,
 				746CBD071570A8FA00B844B1 /* WBSuccessNoticeView.m */,
 				748A6A5B157D0D06003C7655 /* WBStickyNoticeView.h */,
@@ -263,6 +273,8 @@
 				7492FA46157C8CD700FB834C /* WBRedGradientView.m in Sources */,
 				748A6A59157D0B74003C7655 /* WBGrayGradientView.m in Sources */,
 				748A6A5D157D0D06003C7655 /* WBStickyNoticeView.m in Sources */,
+				FED81FA916B97A1C00254985 /* WBNoticeOperation.m in Sources */,
+				FE07240C16BAB0F000B46F59 /* NSOperationQueue+WBNoticeExtensions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.h
+++ b/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.h
@@ -1,0 +1,19 @@
+//
+//  NSOperationQueue+WBNoticeExtensions.h
+//  NoticeView
+//
+//  Created by Johannes Plunien on 1/31/13.
+//  Copyright (c) 2013 Tito Ciuro. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "WBNoticeView.h"
+#import "WBNoticeOperation.h"
+
+@interface NSOperationQueue (WBNoticeExtensions)
+
++ (WBNoticeOperation *)addNoticeView:(WBNoticeView *)noticeView;
++ (WBNoticeOperation *)addNoticeView:(WBNoticeView *)noticeView
+                    filterDuplicates:(BOOL)filterDuplicates;
+
+@end

--- a/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.m
+++ b/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.m
@@ -1,0 +1,38 @@
+//
+//  NSOperationQueue+WBNoticeExtensions.m
+//  NoticeView
+//
+//  Created by Johannes Plunien on 1/31/13.
+//  Copyright (c) 2013 Tito Ciuro. All rights reserved.
+//
+
+#import "NSOperationQueue+WBNoticeExtensions.h"
+
+@implementation NSOperationQueue (WBNoticeExtensions)
+
++ (WBNoticeOperation *)addNoticeView:(WBNoticeView *)noticeView
+{
+    return [self addNoticeView:noticeView filterDuplicates:NO];
+}
+
++ (WBNoticeOperation *)addNoticeView:(WBNoticeView *)noticeView
+                    filterDuplicates:(BOOL)filterDuplicates
+{
+    if (filterDuplicates) {
+        for (NSOperation *operation in [[self mainQueue] operations]) {
+            if ([operation isKindOfClass:[WBNoticeOperation class]] == NO) {
+                continue;
+            }
+            WBNoticeOperation *noticeOperation = (WBNoticeOperation *)operation;
+            if ([noticeOperation.noticeView isEqual:noticeView]) {
+                return nil;
+            }
+        }
+    }
+    WBNoticeOperation *operation = [[WBNoticeOperation alloc] init];
+    operation.noticeView = noticeView;
+    [[self mainQueue] addOperation:operation];
+    return operation;
+}
+
+@end

--- a/NoticeView/WBNoticeView/WBNoticeOperation.h
+++ b/NoticeView/WBNoticeView/WBNoticeOperation.h
@@ -1,0 +1,17 @@
+//
+//  WBNoticeOperation.h
+//  NoticeView
+//
+//  Created by Johannes Plunien on 1/30/13.
+//  Copyright (c) 2013 Tito Ciuro. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "WBNoticeView.h"
+
+@interface WBNoticeOperation : NSOperation
+
+@property (nonatomic, assign) BOOL dismissedInteractively;
+@property (nonatomic, strong) WBNoticeView *noticeView;
+
+@end

--- a/NoticeView/WBNoticeView/WBNoticeOperation.m
+++ b/NoticeView/WBNoticeView/WBNoticeOperation.m
@@ -1,0 +1,37 @@
+//
+//  WBNoticeOperation.m
+//  NoticeView
+//
+//  Created by Johannes Plunien on 1/30/13.
+//  Copyright (c) 2013 Tito Ciuro. All rights reserved.
+//
+
+#import "WBNoticeOperation.h"
+
+@interface WBNoticeOperation ()
+
+@property (nonatomic, assign, getter = isExecuting) BOOL executing;
+@property (nonatomic, assign, getter = isFinished) BOOL finished;
+
+@end
+
+@implementation WBNoticeOperation
+
+- (void)start
+{
+    self.executing = YES;
+    self.finished = NO;
+    __weak __typeof(&*self)weakSelf = self;
+    self.noticeView.dismissalBlock = ^(BOOL dismissedInteractively) {
+        [weakSelf willChangeValueForKey:@"isFinished"];
+        [weakSelf willChangeValueForKey:@"isExecuting"];
+        weakSelf.executing = NO;
+        weakSelf.finished = YES;
+        weakSelf.dismissedInteractively = dismissedInteractively;
+        [weakSelf didChangeValueForKey:@"isExecuting"];
+        [weakSelf didChangeValueForKey:@"isFinished"];
+    };
+    [self.noticeView show];
+}
+
+@end

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -70,6 +70,11 @@
     [self doesNotRecognizeSelector:_cmd];
 }
 
+- (BOOL)isEqual:(WBNoticeView *)object
+{
+    return [self.title isEqual:object.title] && [self.message isEqual:object.message];
+}
+
 #pragma mark -
 
 - (void)displayNotice

--- a/NoticeView/WBViewController.m
+++ b/NoticeView/WBViewController.m
@@ -30,6 +30,7 @@
 #import "WBErrorNoticeView.h"
 #import "WBSuccessNoticeView.h"
 #import "WBStickyNoticeView.h"
+#import "NSOperationQueue+WBNoticeExtensions.h"
 
 @interface WBViewController ()
 @property (nonatomic, readwrite, weak) WBNoticeView *currentNoticeView;
@@ -68,6 +69,16 @@
 {
     WBErrorNoticeView *notice = [WBErrorNoticeView errorNoticeInView:self.view title:@"Network Error" message:@"Check your network connection."];
     [notice show];
+}
+
+- (IBAction)showQueuedErrorNotice:(id)sender
+{
+    WBErrorNoticeView *notice = [WBErrorNoticeView errorNoticeInView:self.view title:@"Queued Network Error" message:@"Check your network connection."];
+    WBNoticeOperation *operation = [NSOperationQueue addNoticeView:notice filterDuplicates:YES];
+    __block WBNoticeOperation *weakOperation = operation;
+    operation.completionBlock = ^{
+        NSLog(@"Queued notice operation dismissed! Interactively: %@", weakOperation.dismissedInteractively ? @"YES" : @"NO");
+    };
 }
 
 - (IBAction)showLargeErrorNotice:(id)sender

--- a/NoticeView/en.lproj/MainStoryboard.storyboard
+++ b/NoticeView/en.lproj/MainStoryboard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="2840" systemVersion="12C54" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="mRO-Fr-kEU">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="3084" systemVersion="12C60" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="mRO-Fr-kEU">
     <dependencies>
-        <deployment defaultVersion="1536" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="1926"/>
+        <deployment defaultVersion="1552" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="2083"/>
     </dependencies>
     <scenes>
         <!--View Controller - NoticeView-->
@@ -75,6 +75,21 @@
                                 </state>
                                 <connections>
                                     <action selector="showSmallErrorNotice:" destination="2" eventType="touchUpInside" id="VRO-SD-itu"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="R6U-fL-LjP">
+                                <rect key="frame" x="170" y="332" width="130" height="37"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
+                                <state key="normal" title="Small Error (Queued)">
+                                    <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <state key="highlighted">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="showQueuedErrorNotice:" destination="2" eventType="touchUpInside" id="ZgN-de-SaW"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="oNn-y7-T1N">
@@ -250,6 +265,7 @@
                 <relationship kind="action" name="dismissStickyNotice:"/>
                 <relationship kind="action" name="showLargeErrorNotice:"/>
                 <relationship kind="action" name="showLargeErrorNoticeBelow:"/>
+                <relationship kind="action" name="showQueuedErrorNotice:"/>
                 <relationship kind="action" name="showSmallErrorNotice:"/>
                 <relationship kind="action" name="showSmallErrorNoticeAndPush:"/>
                 <relationship kind="action" name="showSmallErrorNoticeBelow:"/>


### PR DESCRIPTION
I've created some convenience methods for showing notice views in a queue, one after the other. It's also possible to filter out duplicates. The `isEqual` method just checks if it has the same `title` and same `message`. There's also a new button in the example project called `Small Error (queues)`, which does filter duplicates to demonstrate the new feature. The example code looks like:

``` objc
WBErrorNoticeView *notice = [WBErrorNoticeView errorNoticeInView:self.view title:@"Queued Network Error" message:@"Check your network connection."];
WBNoticeOperation *operation = [NSOperationQueue addNoticeView:notice filterDuplicates:YES];
__block WBNoticeOperation *weakOperation = operation;
operation.completionBlock = ^{
   NSLog(@"Queued notice operation dismissed! Interactively: %@", weakOperation.dismissedInteractively ? @"YES" : @"NO");
};
```
