### PR TITLE
Dismiss notice view instantly after tap.

### DIFF
--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -148,7 +148,7 @@
         // Clear the reference to the dismissal block so that the animation does invoke the block a second time
         self.dismissalBlock = nil;
     }
-    [self dismissNoticeWithDuration:self.duration delay:self.delay hiddenYOrigin:self.hiddenYOrigin];
+    [self dismissNoticeWithDuration:self.duration delay:0.0 hiddenYOrigin:self.hiddenYOrigin];
 }
 
 - (void)dismissAfterTimerExpiration


### PR DESCRIPTION
On the current `master` branch, the tap to dismiss does not instantly dismiss the notice view once the user taps on it. The `dismissalBlock` on the other hand fires instantly. This commit removes the delay, so once the notice view is tapped, it instantly dismisses itself.
