### PR TITLE
Support empty title.

### DIFF
--- a/NoticeView/WBNoticeView/WBErrorNoticeView.m
+++ b/NoticeView/WBNoticeView/WBErrorNoticeView.m
@@ -33,17 +33,21 @@
     
     // Make and add the title label
     float titleYOrigin = 10.0;
-    
-    self.titleLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0, titleYOrigin, viewWidth - 70.0, 16.0)];
-    self.titleLabel.textColor = [UIColor whiteColor];
-    self.titleLabel.shadowOffset = CGSizeMake(0.0, -1.0);
-    self.titleLabel.shadowColor = [UIColor blackColor];
-    self.titleLabel.font = [UIFont boldSystemFontOfSize:14.0];
-    self.titleLabel.backgroundColor = [UIColor clearColor];
-    self.titleLabel.text = self.title;
-    
+    float messageYOrigin = 15.0;
+
+    if ([self.title length] > 0) {
+        self.titleLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0, titleYOrigin, viewWidth - 70.0, 16.0)];
+        self.titleLabel.textColor = [UIColor whiteColor];
+        self.titleLabel.shadowOffset = CGSizeMake(0.0, -1.0);
+        self.titleLabel.shadowColor = [UIColor blackColor];
+        self.titleLabel.font = [UIFont boldSystemFontOfSize:14.0];
+        self.titleLabel.backgroundColor = [UIColor clearColor];
+        self.titleLabel.text = self.title;
+        messageYOrigin = 30.0;
+    }
+
     // Make the message label
-    self.messageLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0, 20.0 + 10.0, viewWidth - 70.0, 12.0)];
+    self.messageLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0, messageYOrigin, viewWidth - 70.0, 12.0)];
     self.messageLabel.font = [UIFont systemFontOfSize:13.0];
     self.messageLabel.textColor = [UIColor colorWithRed:239.0/255.0 green:167.0/255.0 blue:163.0/255.0 alpha:1.0];
     self.messageLabel.backgroundColor = [UIColor clearColor];
@@ -76,7 +80,11 @@
     }
     
     // Add some bottom margin for the notice view
-    noticeViewHeight += 30.0;
+    if ([self.title length] > 0) {
+        noticeViewHeight += 30.0;
+    } else {
+        noticeViewHeight += 20.0;
+    }
     
     // Make sure we hide completely the view, including its shadow
     float hiddenYOrigin = -noticeViewHeight - 20.0;

--- a/NoticeView/WBViewController.m
+++ b/NoticeView/WBViewController.m
@@ -66,13 +66,13 @@
 
 - (IBAction)showSmallErrorNotice:(id)sender
 {
-    WBErrorNoticeView *notice = [WBErrorNoticeView errorNoticeInView:self.view title:@"Network Error" message:@"Check your network connection."];
+    WBErrorNoticeView *notice = [WBErrorNoticeView errorNoticeInView:self.view title:@"" message:@"Check your network connection."];
     [notice show];
 }
 
 - (IBAction)showLargeErrorNotice:(id)sender
 {
-    WBErrorNoticeView *notice = [WBErrorNoticeView errorNoticeInView:self.view title:@"Network Error" message:@"Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."];
+    WBErrorNoticeView *notice = [WBErrorNoticeView errorNoticeInView:self.view title:@"" message:@"Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."];
     [notice setDismissalBlock:^(BOOL dismissedInteractively) {
         NSLog(@"showLargeErrorNotice dismissed!");
     }];


### PR DESCRIPTION
I'd like to support notice views without a title. Unfortunately I could not use `title:nil`, because this automatically uses the default title `Unknown Error` then. So for now I'm using an empty title to not change the behaviour and avoid breaking existing code:

``` objc
[WBErrorNoticeView errorNoticeInView:self.view title:@"" message:@"Check your network connection."];
```

If you think it's okay to break it in a newer version (e.g. `3.1.x`), I'd be happy to make another pull request.
