### PR TITLE
Let subclasses access the dismissbutton.

### DIFF
--- a/NoticeView/WBNoticeView/WBNoticeView+ForSubclassEyesOnly.h
+++ b/NoticeView/WBNoticeView/WBNoticeView+ForSubclassEyesOnly.h
@@ -12,6 +12,7 @@
 
 @interface WBNoticeView (ForSubclassEyesOnly)
 
+@property(nonatomic, strong) UIButton *dismissButton;
 @property(nonatomic, strong) UIView *gradientView;
 @property(nonatomic, strong) UILabel *titleLabel;
 @property(nonatomic, strong) UILabel *messageLabel;

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -11,6 +11,7 @@
 
 @interface WBNoticeView ()
 
+@property(nonatomic, strong) UIButton *dismissButton;
 @property(nonatomic, strong) UIView *gradientView;
 @property(nonatomic, strong) UILabel *titleLabel;
 @property(nonatomic, strong) UILabel *messageLabel;
@@ -80,24 +81,20 @@
 
 - (void)displayNotice
 {
-    // Setup accessiblity on the gradient view
-    NSString *accessibilityLabel = ([self.messageLabel.text length]) ? [NSString stringWithFormat:@"%@, %@", [self.titleLabel text], [self.messageLabel text]]
-                                                       : [self.titleLabel text];
-    self.gradientView.accessibilityTraits = (self.isTapToDismissEnabled) ? UIAccessibilityTraitButton : UIAccessibilityTraitStaticText;
-    self.gradientView.accessibilityLabel = accessibilityLabel;
     self.gradientView.userInteractionEnabled = YES;
-    
+
     // Add tap to dismiss capabilities if desired
     if (self.isTapToDismissEnabled) {
         // Add an invisible button that responds to a manual dismiss
         self.currentNotice = self;
-        UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
-        button.accessibilityLabel = accessibilityLabel;
-        button.frame = self.gradientView.bounds;
-        [button addTarget:self action:@selector(dismissNoticeInteractively) forControlEvents:UIControlEventTouchUpInside];
-        [self.gradientView addSubview:button];
+        self.dismissButton = [UIButton buttonWithType:UIButtonTypeCustom];
+        self.dismissButton.frame = self.gradientView.bounds;
+        [self.dismissButton addTarget:self action:@selector(dismissNoticeInteractively) forControlEvents:UIControlEventTouchUpInside];
+        [self.gradientView addSubview:self.dismissButton];
     }
-    
+
+    [self updateAccessibilityLabels];
+
     //set default originY if WBNoticeViewSlidingModeUp
     if ((self.slidingMode == WBNoticeViewSlidingModeUp) && (self.originY == 0)) {
         self.originY = self.view.bounds.size.height - self.gradientView.bounds.size.height;
@@ -170,6 +167,16 @@
 - (void)dismissAfterTimerExpiration
 {
     [self dismissNoticeWithDuration:self.duration delay:0.0 hiddenYOrigin:self.hiddenYOrigin];
+}
+
+- (void)updateAccessibilityLabels
+{
+    // Setup accessiblity on the gradient view
+    NSString *accessibilityLabel = ([self.messageLabel.text length]) ? [NSString stringWithFormat:@"%@, %@", [self.titleLabel text], [self.messageLabel text]]
+    : [self.titleLabel text];
+    self.gradientView.accessibilityTraits = (self.isTapToDismissEnabled) ? UIAccessibilityTraitButton : UIAccessibilityTraitStaticText;
+    self.gradientView.accessibilityLabel = accessibilityLabel;
+    self.dismissButton.accessibilityLabel = accessibilityLabel;
 }
 
 #pragma mark -


### PR DESCRIPTION
We have a subclass, that can update the `messageLabel.text` while the user is typing. To be able to test that properly via KIF we also need to update the `accessibilityLabel` elements. Therefore I want subclasses to be able to access the `dismissButton` element as well as the `gradientView` element (that's there already).

![Screen Shot 2013-02-04 at 7 41 08 AM](https://f.cloud.github.com/assets/31597/122893/7f529682-6e9a-11e2-877d-185ea720f717.png)
