### PR TITLE
Use own queue to be able to cancel queued noticeViews.

### DIFF
--- a/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.h
+++ b/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.h
@@ -15,5 +15,6 @@
 + (WBNoticeOperation *)addNoticeView:(WBNoticeView *)noticeView;
 + (WBNoticeOperation *)addNoticeView:(WBNoticeView *)noticeView
                     filterDuplicates:(BOOL)filterDuplicates;
++ (void)cancelAllNoticeViews;
 
 @end

--- a/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.h
+++ b/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.h
@@ -16,5 +16,6 @@
 + (WBNoticeOperation *)addNoticeView:(WBNoticeView *)noticeView
                     filterDuplicates:(BOOL)filterDuplicates;
 + (void)cancelAllNoticeViews;
++ (void)cancelAndDismissAllNoticeViews;
 
 @end

--- a/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.m
+++ b/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.m
@@ -10,6 +10,26 @@
 
 @implementation NSOperationQueue (WBNoticeExtensions)
 
+static NSOperationQueue *_noticeQueue = nil;
+
++ (NSOperationQueue *)noticeQueue {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        if (_noticeQueue == nil) {
+            _noticeQueue = [[NSOperationQueue alloc] init];
+            _noticeQueue.maxConcurrentOperationCount = 1;
+        }
+    });
+    return _noticeQueue;
+}
+
+#pragma mark - Public methods
+
++ (void)cancelAllNoticeViews
+{
+    [[self noticeQueue] cancelAllOperations];
+}
+
 + (WBNoticeOperation *)addNoticeView:(WBNoticeView *)noticeView
 {
     return [self addNoticeView:noticeView filterDuplicates:NO];
@@ -19,10 +39,7 @@
                     filterDuplicates:(BOOL)filterDuplicates
 {
     if (filterDuplicates) {
-        for (NSOperation *operation in [[self mainQueue] operations]) {
-            if ([operation isKindOfClass:[WBNoticeOperation class]] == NO) {
-                continue;
-            }
+        for (NSOperation *operation in [[self noticeQueue] operations]) {
             WBNoticeOperation *noticeOperation = (WBNoticeOperation *)operation;
             if ([noticeOperation.noticeView isEqual:noticeView]) {
                 return nil;
@@ -31,7 +48,7 @@
     }
     WBNoticeOperation *operation = [[WBNoticeOperation alloc] init];
     operation.noticeView = noticeView;
-    [[self mainQueue] addOperation:operation];
+    [[self noticeQueue] addOperation:operation];
     return operation;
 }
 

--- a/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.m
+++ b/NoticeView/WBNoticeView/NSOperationQueue+WBNoticeExtensions.m
@@ -30,6 +30,14 @@ static NSOperationQueue *_noticeQueue = nil;
     [[self noticeQueue] cancelAllOperations];
 }
 
++ (void)cancelAndDismissAllNoticeViews
+{
+    for (WBNoticeOperation *operation in [[self noticeQueue] operations]) {
+        [operation.noticeView dismissNotice];
+        [operation cancel];
+    }
+}
+
 + (WBNoticeOperation *)addNoticeView:(WBNoticeView *)noticeView
 {
     return [self addNoticeView:noticeView filterDuplicates:NO];

--- a/NoticeView/WBNoticeView/WBNoticeOperation.m
+++ b/NoticeView/WBNoticeView/WBNoticeOperation.m
@@ -11,6 +11,7 @@
 @interface WBNoticeOperation ()
 
 @property (nonatomic, assign, getter = isExecuting) BOOL executing;
+@property (nonatomic, assign, getter = isCancelled) BOOL cancelled;
 @property (nonatomic, assign, getter = isFinished) BOOL finished;
 
 @end
@@ -19,8 +20,13 @@
 
 - (void)start
 {
+    if (self.cancelled) {
+        return;
+    }
+
     self.executing = YES;
     self.finished = NO;
+
     __weak __typeof(&*self)weakSelf = self;
     self.noticeView.dismissalBlock = ^(BOOL dismissedInteractively) {
         [weakSelf willChangeValueForKey:@"isFinished"];
@@ -31,7 +37,15 @@
         [weakSelf didChangeValueForKey:@"isExecuting"];
         [weakSelf didChangeValueForKey:@"isFinished"];
     };
-    [self.noticeView show];
+
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        [self.noticeView show];
+    });
+}
+
+- (void)cancel
+{
+    self.cancelled = YES;
 }
 
 @end


### PR DESCRIPTION
I have changed the `NSOperationQueue` implementation a little bit: Instead of using the `mainQueue`, now we have an own seperate queue for the `NoticeViewOperation` operations. This gives us the advantage, that we can cancel all of them, if necessary:

``` objc
[NSOperationQueue cancelAllNoticeViews];
```
