### PR TITLE
Add new `floating` (BOOL) property. (KVO + UIScrollView solution)

### DIFF
--- a/NoticeView.xcodeproj/project.pbxproj
+++ b/NoticeView.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		250628781651F7DC00D3443E /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 250628771651F7DB00D3443E /* Default-568h@2x.png */; };
+		3EA90DC617086FF70045E620 /* WBScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EA90DC517086FF70045E620 /* WBScrollViewController.m */; };
 		592BDDE915645BEE00B78820 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 592BDDE115645BEE00B78820 /* Default.png */; };
 		592BDDEA15645BEE00B78820 /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 592BDDE215645BEE00B78820 /* Default@2x.png */; };
 		592BDDEB15645BEE00B78820 /* NoticeView.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 592BDDE415645BEE00B78820 /* NoticeView.bundle */; };
@@ -36,6 +37,8 @@
 /* Begin PBXFileReference section */
 		250628731651E78600D3443E /* WBNoticeView+ForSubclassEyesOnly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WBNoticeView+ForSubclassEyesOnly.h"; sourceTree = "<group>"; };
 		250628771651F7DB00D3443E /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "../../Default-568h@2x.png"; sourceTree = "<group>"; };
+		3EA90DC417086FF70045E620 /* WBScrollViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WBScrollViewController.h; sourceTree = "<group>"; };
+		3EA90DC517086FF70045E620 /* WBScrollViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WBScrollViewController.m; sourceTree = "<group>"; };
 		592BDDE115645BEE00B78820 /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
 		592BDDE215645BEE00B78820 /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x.png"; sourceTree = "<group>"; };
 		592BDDE415645BEE00B78820 /* NoticeView.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = NoticeView.bundle; sourceTree = "<group>"; };
@@ -154,6 +157,8 @@
 				59A782441562F5F70001F08D /* MainStoryboard.storyboard */,
 				59A782411562F5F70001F08D /* WBAppDelegate.h */,
 				59A782421562F5F70001F08D /* WBAppDelegate.m */,
+				3EA90DC417086FF70045E620 /* WBScrollViewController.h */,
+				3EA90DC517086FF70045E620 /* WBScrollViewController.m */,
 				59A782471562F5F80001F08D /* WBViewController.h */,
 				59A782481562F5F80001F08D /* WBViewController.m */,
 				592BDDE315645BEE00B78820 /* WBNoticeView */,
@@ -275,6 +280,7 @@
 				748A6A5D157D0D06003C7655 /* WBStickyNoticeView.m in Sources */,
 				FED81FA916B97A1C00254985 /* WBNoticeOperation.m in Sources */,
 				FE07240C16BAB0F000B46F59 /* NSOperationQueue+WBNoticeExtensions.m in Sources */,
+				3EA90DC617086FF70045E620 /* WBScrollViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NoticeView/WBNoticeView/WBNoticeView.h
+++ b/NoticeView/WBNoticeView/WBNoticeView.h
@@ -103,6 +103,13 @@ typedef enum WBNoticeViewSlidingMode {
 */
 @property WBNoticeViewSlidingMode slidingMode;
 
+/**
+ A Boolean value that determines if the notice will be floating. If added to a `UIScrollView`, it
+ will have a fixed position while scrolling.
+
+ **Default**: `NO`
+ */
+@property (nonatomic, readwrite, getter = isFloating) BOOL floating;
 
 ///----------------------------------------
 /// @name Showing and Dismissing the Notice

--- a/NoticeView/WBScrollViewController.h
+++ b/NoticeView/WBScrollViewController.h
@@ -1,0 +1,13 @@
+//
+//  WBScrollViewController.h
+//  NoticeView
+//
+//  Created by Johannes Plunien on 3/31/13.
+//  Copyright (c) 2013 Tito Ciuro. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface WBScrollViewController : UITableViewController
+
+@end

--- a/NoticeView/WBScrollViewController.h
+++ b/NoticeView/WBScrollViewController.h
@@ -10,4 +10,6 @@
 
 @interface WBScrollViewController : UITableViewController
 
+@property (nonatomic, assign) BOOL floating;
+
 @end

--- a/NoticeView/WBScrollViewController.m
+++ b/NoticeView/WBScrollViewController.m
@@ -1,0 +1,55 @@
+//
+//  WBScrollViewController.m
+//  NoticeView
+//
+//  Created by Johannes Plunien on 3/31/13.
+//  Copyright (c) 2013 Tito Ciuro. All rights reserved.
+//
+
+#import "WBErrorNoticeView.h"
+#import "WBScrollViewController.h"
+
+@interface WBScrollViewController ()
+
+@end
+
+@implementation WBScrollViewController
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+
+    [self scrollToRow:2];
+    [self performBlock:^{
+        [self showNoticeView];
+        [self performBlock:^{
+            [self scrollToRow:1];
+        } afterDelay:1.0];
+    } afterDelay:0.31];
+}
+
+- (void)performBlock:(void (^)(void))block afterDelay:(NSTimeInterval)delay
+{
+	int64_t delta = (int64_t)(1.0e9 * delay);
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delta), dispatch_get_main_queue(), block);
+}
+
+- (void)scrollToRow:(NSInteger)row
+{
+    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:row inSection:0];
+    [self.tableView scrollToRowAtIndexPath:indexPath
+                          atScrollPosition:UITableViewScrollPositionTop
+                                  animated:YES];
+}
+
+- (void)showNoticeView
+{
+    WBErrorNoticeView *notice = [WBErrorNoticeView errorNoticeInView:self.view
+                                                               title:@"Network Error"
+                                                             message:@"Check your network connection."];
+    notice.sticky = YES;
+    notice.tapToDismissEnabled = YES;
+    [notice show];
+}
+
+@end

--- a/NoticeView/WBScrollViewController.m
+++ b/NoticeView/WBScrollViewController.m
@@ -49,6 +49,7 @@
                                                              message:@"Check your network connection."];
     notice.sticky = YES;
     notice.tapToDismissEnabled = YES;
+    notice.floating = self.floating;
     [notice show];
 }
 

--- a/NoticeView/WBViewController.m
+++ b/NoticeView/WBViewController.m
@@ -25,6 +25,7 @@
 // THE SOFTWARE
 //
 
+#import "WBScrollViewController.h"
 #import "WBViewController.h"
 #import "WBNoticeView.h"
 #import "WBErrorNoticeView.h"
@@ -184,6 +185,13 @@
 - (IBAction)dismissStickyNotice:(id)sender
 {
     [self.currentNoticeView dismissNotice];
+}
+
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    if ([segue.identifier isEqualToString:@"Floating"]) {
+        WBScrollViewController *controller = [segue destinationViewController];
+        controller.floating = YES;
+    }
 }
 
 @end

--- a/NoticeView/en.lproj/MainStoryboard.storyboard
+++ b/NoticeView/en.lproj/MainStoryboard.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="3084" systemVersion="12C60" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="mRO-Fr-kEU">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="3084" systemVersion="12D78" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="mRO-Fr-kEU">
     <dependencies>
         <deployment defaultVersion="1552" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="2083"/>
@@ -14,7 +14,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="Vg3-qF-Q8T">
-                                <rect key="frame" x="170" y="64" width="130" height="37"/>
+                                <rect key="frame" x="170" y="52" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Small Error Below">
@@ -29,7 +29,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="XR3-Kf-0Pf">
-                                <rect key="frame" x="170" y="109" width="130" height="37"/>
+                                <rect key="frame" x="170" y="97" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Large Error Below">
@@ -44,7 +44,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="gi6-oq-xIu">
-                                <rect key="frame" x="170" y="154" width="130" height="37"/>
+                                <rect key="frame" x="170" y="142" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Small Success Below">
@@ -63,7 +63,7 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="Xwf-eU-mzM">
-                                <rect key="frame" x="22" y="64" width="130" height="37"/>
+                                <rect key="frame" x="22" y="52" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Small Error">
@@ -78,7 +78,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="R6U-fL-LjP">
-                                <rect key="frame" x="170" y="332" width="130" height="37"/>
+                                <rect key="frame" x="170" y="320" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Small Error (Queued)">
@@ -92,8 +92,23 @@
                                     <action selector="showQueuedErrorNotice:" destination="2" eventType="touchUpInside" id="ZgN-de-SaW"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="X3P-wF-0WT">
+                                <rect key="frame" x="22" y="369" width="130" height="37"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
+                                <state key="normal" title="Scroll View">
+                                    <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <state key="highlighted">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <segue destination="fDF-9q-kwW" kind="push" id="YS7-ix-L39"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="oNn-y7-T1N">
-                                <rect key="frame" x="22" y="109" width="130" height="37"/>
+                                <rect key="frame" x="22" y="97" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Large Error">
@@ -108,7 +123,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="WpV-6q-VuB">
-                                <rect key="frame" x="22" y="154" width="130" height="37"/>
+                                <rect key="frame" x="22" y="142" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Small Success">
@@ -123,7 +138,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="ohN-nb-77O">
-                                <rect key="frame" x="170" y="199" width="130" height="37"/>
+                                <rect key="frame" x="170" y="187" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Sticky Below">
@@ -138,7 +153,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="Uso-1A-Af2">
-                                <rect key="frame" x="22" y="199" width="130" height="37"/>
+                                <rect key="frame" x="22" y="187" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Sticky">
@@ -153,7 +168,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="L3v-hl-Vfi">
-                                <rect key="frame" x="22" y="288" width="130" height="37"/>
+                                <rect key="frame" x="22" y="276" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Sticky Error">
@@ -168,7 +183,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="C6H-48-t6v">
-                                <rect key="frame" x="22" y="332" width="130" height="37"/>
+                                <rect key="frame" x="22" y="320" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Dismiss Sticky Error">
@@ -183,7 +198,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="cee-Xq-cSc">
-                                <rect key="frame" x="22" y="244" width="130" height="37"/>
+                                <rect key="frame" x="22" y="232" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Show And Push">
@@ -198,7 +213,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="FBJ-Ol-wtM">
-                                <rect key="frame" x="170" y="244" width="130" height="37"/>
+                                <rect key="frame" x="170" y="232" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Sticky Push">
@@ -213,7 +228,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="m37-qX-16L">
-                                <rect key="frame" x="170" y="288" width="130" height="37"/>
+                                <rect key="frame" x="170" y="276" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                 <state key="normal" title="Sticky Error Push">
@@ -239,6 +254,211 @@
             </objects>
             <point key="canvasLocation" x="585" y="218"/>
         </scene>
+        <!--Scroll View Controller - ScrollView-->
+        <scene sceneID="2rr-rp-rqL">
+            <objects>
+                <tableViewController id="fDF-9q-kwW" customClass="WBScrollViewController" sceneMemberID="viewController">
+                    <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="Qxm-ia-8a8">
+                        <rect key="frame" x="0.0" y="64" width="320" height="416"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <sections>
+                            <tableViewSection id="kBy-AG-D4z">
+                                <cells>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="One" textLabel="F8N-2Q-cHU" rowHeight="120" style="IBUITableViewCellStyleDefault" id="ROB-qY-Oec">
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="119"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="One" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="F8N-2Q-cHU">
+                                                    <rect key="frame" x="10" y="0.0" width="300" height="119"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Two" textLabel="rNU-e0-q7M" rowHeight="120" style="IBUITableViewCellStyleDefault" id="cXt-0n-XEj">
+                                        <rect key="frame" x="0.0" y="120" width="320" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="119"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Two" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="rNU-e0-q7M">
+                                                    <rect key="frame" x="10" y="0.0" width="300" height="119"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Three" textLabel="X4x-nR-I1S" rowHeight="120" style="IBUITableViewCellStyleDefault" id="Jbm-Ay-YYb">
+                                        <rect key="frame" x="0.0" y="240" width="320" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="119"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Three" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="X4x-nR-I1S">
+                                                    <rect key="frame" x="10" y="0.0" width="300" height="119"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Four" textLabel="TNc-LL-2af" rowHeight="120" style="IBUITableViewCellStyleDefault" id="0K1-S9-Jjf">
+                                        <rect key="frame" x="0.0" y="360" width="320" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="119"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Four" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TNc-LL-2af">
+                                                    <rect key="frame" x="10" y="0.0" width="300" height="119"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Five" textLabel="yTm-JL-zw2" rowHeight="120" style="IBUITableViewCellStyleDefault" id="ZKc-jN-yk0">
+                                        <rect key="frame" x="0.0" y="480" width="320" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="119"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Five" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="yTm-JL-zw2">
+                                                    <rect key="frame" x="10" y="0.0" width="300" height="119"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Six" textLabel="jNB-CT-EuH" rowHeight="120" style="IBUITableViewCellStyleDefault" id="iDQ-ID-XeA">
+                                        <rect key="frame" x="0.0" y="600" width="320" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="119"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Six" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jNB-CT-EuH">
+                                                    <rect key="frame" x="10" y="0.0" width="300" height="119"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Seven" textLabel="78o-XT-N8K" rowHeight="120" style="IBUITableViewCellStyleDefault" id="zvE-q0-QFp">
+                                        <rect key="frame" x="0.0" y="720" width="320" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="119"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Seven" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="78o-XT-N8K">
+                                                    <rect key="frame" x="10" y="0.0" width="300" height="119"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Eight" textLabel="kBe-Fz-Ssf" rowHeight="120" style="IBUITableViewCellStyleDefault" id="cZL-hJ-vmS">
+                                        <rect key="frame" x="0.0" y="840" width="320" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="119"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Eight" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="kBe-Fz-Ssf">
+                                                    <rect key="frame" x="10" y="0.0" width="300" height="119"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Nine" textLabel="Kcx-jW-vSC" rowHeight="120" style="IBUITableViewCellStyleDefault" id="itW-Gs-0fL">
+                                        <rect key="frame" x="0.0" y="960" width="320" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="119"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Nine" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Kcx-jW-vSC">
+                                                    <rect key="frame" x="10" y="0.0" width="300" height="79"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Ten" textLabel="vBu-2r-Idr" rowHeight="120" style="IBUITableViewCellStyleDefault" id="6ut-fu-Xkz">
+                                        <rect key="frame" x="0.0" y="1080" width="320" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="119"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Ten" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="vBu-2r-Idr">
+                                                    <rect key="frame" x="10" y="0.0" width="300" height="79"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="fDF-9q-kwW" id="aIR-zA-v6B"/>
+                            <outlet property="delegate" destination="fDF-9q-kwW" id="seV-Fn-CuP"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="ScrollView" id="zNW-83-cCc"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="I2R-VB-YU4" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1039" y="218"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="TQy-EY-xtH">
             <objects>
@@ -259,22 +479,21 @@
         <image name="navigationBar.png" width="320" height="44"/>
     </resources>
     <classes>
+        <class className="WBScrollViewController" superclassName="UITableViewController">
+            <source key="sourceIdentifier" type="project" relativePath="./Classes/WBScrollViewController.h"/>
+        </class>
         <class className="WBViewController" superclassName="UIViewController">
             <source key="sourceIdentifier" type="project" relativePath="./Classes/WBViewController.h"/>
             <relationships>
                 <relationship kind="action" name="dismissStickyNotice:"/>
                 <relationship kind="action" name="showLargeErrorNotice:"/>
                 <relationship kind="action" name="showLargeErrorNoticeBelow:"/>
-                <relationship kind="action" name="showQueuedErrorNotice:"/>
                 <relationship kind="action" name="showSmallErrorNotice:"/>
                 <relationship kind="action" name="showSmallErrorNoticeAndPush:"/>
                 <relationship kind="action" name="showSmallErrorNoticeBelow:"/>
-                <relationship kind="action" name="showSmallStickyNotice:"/>
                 <relationship kind="action" name="showSmallStickyNoticeBelow:"/>
                 <relationship kind="action" name="showSmallSuccessNotice:"/>
                 <relationship kind="action" name="showSmallSuccessNoticeBelow:"/>
-                <relationship kind="action" name="showStickyError:"/>
-                <relationship kind="action" name="showStickyErrorNoticeAndPush:"/>
                 <relationship kind="action" name="showStickyNoticeAndPush:"/>
                 <relationship kind="outlet" name="headerView" candidateClass="UIImageView"/>
             </relationships>

--- a/NoticeView/en.lproj/MainStoryboard.storyboard
+++ b/NoticeView/en.lproj/MainStoryboard.storyboard
@@ -107,6 +107,21 @@
                                     <segue destination="fDF-9q-kwW" kind="push" id="YS7-ix-L39"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="dRV-yD-Y8H">
+                                <rect key="frame" x="167" y="369" width="136" height="37"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
+                                <state key="normal" title="Scroll View (Floating)">
+                                    <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <state key="highlighted">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <segue destination="fDF-9q-kwW" kind="push" identifier="Floating" id="FUF-pc-qTb"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="oNn-y7-T1N">
                                 <rect key="frame" x="22" y="97" width="130" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -504,4 +519,7 @@
         <simulatedOrientationMetrics key="orientation"/>
         <simulatedScreenMetrics key="destination"/>
     </simulatedMetricsContainer>
+    <inferredMetricsTieBreakers>
+        <segue reference="FUF-pc-qTb"/>
+    </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
This property allows the `NoticeView` to be floating at the same position in a `UIScrollView`, while the user is scrolling. It's pretty much the same implementation as in the pull request #41, using KVO. It's just based upon the most recent HEAD of master, and includes some fix (leaked observers). There're also two new buttons in the example project to test it.

I've added this new property on purpose: Maybe there are `NoticeView` users out there who expect the `NoticeView` to be scrolling inside a `UIScrollView` instead of floating. Having the extra property will not break existing apps.
