### PR TITLE
Option to opt out from a dismissal in the dismissal block

### DIFF
--- a/NoticeView/WBNoticeView/WBErrorNoticeView.m
+++ b/NoticeView/WBNoticeView/WBErrorNoticeView.m
@@ -33,8 +33,11 @@
     
     // Make and add the title label
     float titleYOrigin = 10.0;
-    
-    self.titleLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0, titleYOrigin, viewWidth - 70.0, 16.0)];
+
+    self.titleLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0 + (self.contentInset.left), titleYOrigin + (self.contentInset.top), viewWidth - 70.0 - (self.contentInset.right+self.contentInset.left) , 16.0)];
+//    NSLog(@"titleLabelFrame: %@", NSStringFromCGRect(self.titleLabel.frame));
+//    self.titleLabel.layer.borderWidth = 1;
+//    self.titleLabel.layer.borderColor = [UIColor greenColor].CGColor;
     self.titleLabel.textColor = [UIColor whiteColor];
     self.titleLabel.shadowOffset = CGSizeMake(0.0, -1.0);
     self.titleLabel.shadowColor = [UIColor blackColor];
@@ -43,7 +46,7 @@
     self.titleLabel.text = self.title;
     
     // Make the message label
-    self.messageLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0, 20.0 + 10.0, viewWidth - 70.0, 12.0)];
+    self.messageLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0 + (self.contentInset.left), 20.0 + 10.0 + (self.contentInset.top), viewWidth - 70.0 - (self.contentInset.right+self.contentInset.left), 12.0)];
     self.messageLabel.font = [UIFont systemFontOfSize:13.0];
     self.messageLabel.textColor = [UIColor colorWithRed:239.0/255.0 green:167.0/255.0 blue:163.0/255.0 alpha:1.0];
     self.messageLabel.backgroundColor = [UIColor clearColor];

--- a/NoticeView/WBNoticeView/WBNoticeView.h
+++ b/NoticeView/WBNoticeView/WBNoticeView.h
@@ -136,8 +136,18 @@ typedef enum WBNoticeViewSlidingMode {
  
  The block accepts a single Boolean value that indicates if the notice was dismissed interactively by the user or was dismissed due to expiration of the display interval.
  
- @param block The block to be executed when the notice is dismissed.
+ @param block The block to be executed when the notice receives a dismissal.
  */
 - (void)setDismissalBlock:(void (^)(BOOL dismissedInteractively))block;
+
+/**
+ Sets a block to be executed when the notice is dismissed.
+ 
+ The block accepts a Boolean value that indicates if the notice was dismissed interactively by the user or was dismissed due to expiration of the display interval.
+ The block also accepts a boolean pointer that makes it possible to make the dismissal optional depending on the resulting block. (Good for putting up an AlertView in the block to check if the user is sure)
+ 
+ @param block The block to be executed when the notice receives a dismissal.
+ */
+- (void)setDismissalBlockWithOptionalDismiss:(void (^)(BOOL dismissedInteractively, BOOL *dismissAfterBlock))block;
 
 @end

--- a/NoticeView/WBNoticeView/WBNoticeView.h
+++ b/NoticeView/WBNoticeView/WBNoticeView.h
@@ -43,6 +43,11 @@ typedef enum WBNoticeViewSlidingMode {
 @property (nonatomic, weak) UIView *view;
 
 /**
+ Content insets
+ */
+@property (nonatomic) UIEdgeInsets contentInset;
+
+/**
  The title text for the notice.
  
  **Default**: `"Unknown Error"`

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -20,6 +20,7 @@
 @property(nonatomic, assign) CGFloat hiddenYOrigin;
 @property(nonatomic, strong) WBNoticeView *currentNotice;
 @property(nonatomic, copy) void (^dismissalBlock)(BOOL dismissedInteractively);
+@property(nonatomic, copy) void (^dismissalBlockWithOptionalDismiss)(BOOL dismissedInteractively, BOOL *dismissAfterBlock);
 @property(nonatomic, strong) NSTimer *displayTimer;
 
 - (void)dismissNoticeWithDuration:(NSTimeInterval)duration
@@ -44,6 +45,7 @@
 @synthesize originY = _originY;
 @synthesize sticky = _sticky;
 @synthesize dismissalBlock = _dismissalBlock;
+@synthesize dismissalBlockWithOptionalDismiss = _dismissalBlockWithOptionalDismiss;
 @synthesize floating = _floating;
 
 - (id)initWithView:(UIView *)view title:(NSString *)title
@@ -140,7 +142,16 @@
         }
         self.gradientView.frame = newFrame;
     } completion:^ (BOOL finished) {
-        if (self.dismissalBlock) self.dismissalBlock(NO);
+        
+        if (self.dismissalBlock) {
+            self.dismissalBlock(NO);
+        }
+        
+        if (self.dismissalBlockWithOptionalDismiss) {
+            BOOL dismissAfterBlock = YES;
+            self.dismissalBlockWithOptionalDismiss(NO, &dismissAfterBlock);
+        }
+        
         // Cleanup
         [self cleanup];
     }];
@@ -154,14 +165,27 @@
 
 - (void)dismissNoticeInteractively
 {
+    // TODO: Should this timer invalidate here or when the dismissalBlock is set to nil further down?
     [self.displayTimer invalidate];
+    
     if (self.dismissalBlock) {
         self.dismissalBlock(YES);
-        
+    }
+ 
+    // By default we want to dismiss after the block has been called
+    BOOL dismissAfterBlock = YES;
+    if (self.dismissalBlockWithOptionalDismiss) {
+        self.dismissalBlockWithOptionalDismiss(YES, &dismissAfterBlock);
+    }
+    
+    // Lets check if the block wanted us to dismiss
+    if (dismissAfterBlock) {
         // Clear the reference to the dismissal block so that the animation does invoke the block a second time
         self.dismissalBlock = nil;
+        self.dismissalBlockWithOptionalDismiss = nil;
+        
+        [self dismissNoticeWithDuration:self.duration delay:0 hiddenYOrigin:self.hiddenYOrigin];
     }
-    [self dismissNoticeWithDuration:self.duration delay:0 hiddenYOrigin:self.hiddenYOrigin];
 }
 
 - (void)dismissAfterTimerExpiration

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -62,6 +62,7 @@
         _tapToDismissEnabled = YES;
         _slidingMode = WBNoticeViewSlidingModeDown;
         _floating = NO;
+        _contentInset = UIEdgeInsetsMake(0,0,0,0); // No insets as default
     }
     return self;
 }

--- a/NoticeView/WBNoticeView/WBStickyNoticeView.m
+++ b/NoticeView/WBNoticeView/WBStickyNoticeView.m
@@ -34,7 +34,7 @@
     CGFloat messageLineHeight = 30.0;
     
     // Make and add the title label
-    self.titleLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0, 8.0, viewWidth - 70.0, 16.0)];
+    self.titleLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0 + (self.contentInset.left), 8.0 + (self.contentInset.top), viewWidth - 70.0 - (self.contentInset.right+self.contentInset.left) , 16.0)];
     self.titleLabel.textColor = [UIColor blackColor];
     self.titleLabel.shadowOffset = CGSizeMake(0.0, 1.0);
     self.titleLabel.shadowColor = [UIColor whiteColor];

--- a/NoticeView/WBNoticeView/WBSuccessNoticeView.m
+++ b/NoticeView/WBNoticeView/WBSuccessNoticeView.m
@@ -35,7 +35,7 @@
     
     // Make and add the title label
     float titleYOrigin = 18.0;
-    self.titleLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0, titleYOrigin, viewWidth - 70.0, 16.0)];
+    self.titleLabel = [[UILabel alloc]initWithFrame:CGRectMake(55.0 + (self.contentInset.left), titleYOrigin + (self.contentInset.top), viewWidth - 70.0 - (self.contentInset.right+self.contentInset.left) , 16.0)];
     self.titleLabel.textColor = [UIColor whiteColor];
     self.titleLabel.shadowOffset = CGSizeMake(0.0, -1.0);
     self.titleLabel.shadowColor = [UIColor blackColor];


### PR DESCRIPTION
Added `-setDismissalBlockWithOptionalDismiss:` that accepts a second block attribute that is a BOOL pointer. You can then opt out from dismissal of the `NoticeView` from the block. This is good when you want the user to be able to, for example, tap a sticky `NoticeView`, get an `UIAlertView` that wants a confirmation from the user and depending on the outcome dismiss the `NoticeView` or not.

Usage

``` objective-c
[self.noticeView setDismissalBlockWithOptionalDismiss:^(BOOL dismissedInteractively, BOOL *dismissAfterBlock) {
    *dismissAfterBlock = YES; // or NO if you don't want the NoticeView to be dismissed
}];
```

Please take a look and give me a shout if something is trollish.
