### PR TITLE
podspec 3.0.7, require iOS 5.0 for __weak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: objective-c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: objective-c

--- a/NoticeView.podspec
+++ b/NoticeView.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Tito Ciuro' => 'tciuro@mac.com' }
   s.source       = { :git => 'https://github.com/tciuro/NoticeView.git', :tag => '3.0.7' }
   s.platform     = :ios
+  s.ios.deployment_target = '5.0'
   s.source_files = 'NoticeView/WBNoticeView/*.{m,h}'
   s.frameworks   = 'Foundation', 'UIKit', 'CoreGraphics', 'QuartzCore'
   s.resources    = 'NoticeView/WBNoticeView/NoticeView.bundle'

--- a/NoticeView.podspec
+++ b/NoticeView.podspec
@@ -7,7 +7,6 @@ Pod::Spec.new do |s|
   s.author       = { 'Tito Ciuro' => 'tciuro@mac.com' }
   s.source       = { :git => 'https://github.com/tciuro/NoticeView.git', :tag => '3.0.7' }
   s.platform     = :ios
-  s.ios.deployment_target = '5.0'
   s.source_files = 'NoticeView/WBNoticeView/*.{m,h}'
   s.frameworks   = 'Foundation', 'UIKit', 'CoreGraphics', 'QuartzCore'
   s.resources    = 'NoticeView/WBNoticeView/NoticeView.bundle'


### PR DESCRIPTION
I submitted your podspec update in a pull request to the master repo ( https://github.com/CocoaPods/Specs/pull/3143 ) and it initially failed because it was defaulting to iOS 4.3 even though it uses __weak.
